### PR TITLE
add workaround for missing pystache module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN apk --no-cache add \
     git \
     py3-pip
 
+RUN pip install pystache>=0.6.0 --prefer-binary \
+    -f https://github.com/sarnold/pystache/releases/
+
 RUN pip install gitchangelog>=3.0.9 --prefer-binary \
     -f https://github.com/sarnold/gitchangelog/releases/
 


### PR DESCRIPTION
* force pystache install in Docker env
* work-around for bare Pypi dep being ignored and causing CI errors:
  `Required 'pystache' python module not found.`
* for now install `pystache` release wheel from sarnold/pystache before `gitchangelog` install